### PR TITLE
Add AO voltage setting and reduce headroom on ACQ465 voltage

### DIFF
--- a/CARE/choose_vap
+++ b/CARE/choose_vap
@@ -50,7 +50,7 @@ do
 			VRANGE=13;;
 		ACQ465*)
 			echo "# ACQ465 DETECTED set VRANGE 10"
-			VRANGE=10;;
+			VRANGE=9;;
 		BOLO*)
 			echo "# BOLO DETECTED set VRANGE 12"
 			VRANGE=12;;

--- a/CARE/choose_vap
+++ b/CARE/choose_vap
@@ -54,6 +54,10 @@ do
 		BOLO*)
 			echo "# BOLO DETECTED set VRANGE 12"
 			VRANGE=12;;
+		AO*)
+			echo "# $file: FPN $FRU_PART_NUM PN $PN"
+			echo "# AO DETECTED set VRANGE 13.5"
+			VRANGE=13.5;;
 		*)
 			VSPEC=${PN##*-}
 			VSPEC=$(get_vr $PN)


### PR DESCRIPTION
AO boards incorrectly defaulting to 5V as not dealt with in case statement.

Also reduced headroom in ACQ465 to burn less power.