### PR TITLE
Modify how ACQ465 is initialized

### DIFF
--- a/CARE/acq465.init
+++ b/CARE/acq465.init
@@ -68,9 +68,6 @@ acq465_knobs makeLinks >/tmp/makeLinks
 
 cat - >/tmp/acq465_init.job <<EOF
 #!/bin/sh
-while [ ! -e  /var/www/d-tacq/rc-user-complete ]; do
-	sleep 3
-done
 echo acq465_init.job \$(cat /var/www/d-tacq/rc-user-complete)
 EOF
 
@@ -103,8 +100,4 @@ EOF
 done
 
 chmod a+rx /tmp/acq465_init.job
-nice /tmp/acq465_init.job &
-
-
-
 

--- a/CARE/acq465_adc.init
+++ b/CARE/acq465_adc.init
@@ -146,12 +146,19 @@ check_digif() {
 logger -t acq465_adc.init 01
 caput $(hostname):0:ACQ465:POLL 0
 
+set top_retry=0
+
 while true; do
 	reg_check_fail=0
 	pll_check_fail=0
 	fsettle_fail=0
 	digif_check_fail=0
 	write_regs
+
+	top_retry=$((top_retry+1))
+	if [ $top_retry -gt 10 ]; then
+	    break
+	fi
 
 	### Check all regs
 	acq465_readall


### PR DESCRIPTION
Initialization is now called explicitly during boot.
It was previously called as part of a job run upon the completion of rc.user file.
This was leading to multiple writes to registers that the module is sensitive to.

The job is now defined during boot, explicitly called during boot, and explicitly
called again each time a sync_role is performed.